### PR TITLE
Allow moving a technology already in the queue to front

### DIFF
--- a/locale/en/UltimateResearchQueue.cfg
+++ b/locale/en/UltimateResearchQueue.cfg
@@ -24,6 +24,7 @@ urq-welcome=[font=default-bold]Welcome to Ultimate Research Queue![/font]\n\nCli
 
 [message]
 urq-already-in-queue=This technology is already queued for research
+urq-already-in-front-of-queue=This technology and its prerequisites are already in the front of the queue
 urq-already-researched=This technology is already researched
 urq-has-disabled-prerequisites=One or more prerequisites is disabled
 urq-queue-is-full=Research queue is full

--- a/research-queue.lua
+++ b/research-queue.lua
@@ -124,6 +124,23 @@ function research_queue.get_research_state(self, technology)
   return constants.research_state.not_available
 end
 
+--- @param self ResearchQueue
+--- @param technology LuaTechnology
+--- @param level uint
+--- @return uint
+function research_queue.get_position(self, technology, level)
+  local node = self.head
+  local position = 1
+  while node do
+    if node.technology == technology and node.level == level then
+      return position
+    end
+    node = node.next
+    position = position + 1
+  end
+  return 0
+end
+
 --- Add a technology and its prerequisites to the queue.
 --- @param self ResearchQueue
 --- @param technology LuaTechnology
@@ -328,6 +345,13 @@ function research_queue.push_front(self, technology, level)
   end
   if research_queue.contains(self, technology, level) then
     add_technology(to_move, technology, level, self)
+    --- Check if it's already in the front of the queue and this will be a no-op
+    --- We assume that to_research will be empty since its prerequisites will already be in
+    old_position = research_queue.get_position(self, technology, level)
+    new_position = #to_move
+    if new_position == old_position then
+      return { "message.urq-already-in-front-of-queue" }
+    end
   else
     add_technology(to_research, technology, level, self)
   end

--- a/research-queue.lua
+++ b/research-queue.lua
@@ -302,9 +302,6 @@ function research_queue.push_front(self, technology, level)
   local research_state = self.force_table.research_states[technology.name]
   if research_state == constants.research_state.researched then
     return { "message.urq-already-researched" }
-  elseif research_queue.contains(self, technology, level) then
-    -- TODO: Move to front of queue
-    return { "message.urq-already-in-queue" }
   end
   --- @type TechnologyAndLevel[]
   local to_research = {}
@@ -329,7 +326,11 @@ function research_queue.push_front(self, technology, level)
     local highest = research_queue.get_highest_level(self, technology)
     add_technology(to_move, technology, highest)
   end
-  add_technology(to_research, technology, level, self)
+  if research_queue.contains(self, technology, level) then
+    add_technology(to_move, technology, level, self)
+  else
+    add_technology(to_research, technology, level, self)
+  end
   -- Check for errors
   local num_to_research = #to_research
   if num_to_research > constants.queue_limit then


### PR DESCRIPTION
Normally, as a user you need to remove the technology and re-add it to the front of the queue. This does it automatically for you.

It also checks if it's already in the front of the queue, and gives a warning if so.